### PR TITLE
Updated CUDA loading message

### DIFF
--- a/src/cueinsum.jl
+++ b/src/cueinsum.jl
@@ -1,7 +1,7 @@
 using .CuArrays
 using .CuArrays.CUDAnative
 
-println("OMEinsum: YOU FIND CUDA!")
+@info "Loading support for OMEinsum when using CuArrays"
 
 include("cudapatch.jl")
 


### PR DESCRIPTION
I found the existing message ambiguous. It could be interpreted as an imperative: you! go find CUDA because I can't find it. This revision spells out more explicitly what is happening using an `@info` message.